### PR TITLE
miss ] after array];

### DIFF
--- a/chapter5/basic_of_functionalReactivePixels.md
+++ b/chapter5/basic_of_functionalReactivePixels.md
@@ -163,7 +163,7 @@ self.apiHelper = [[PXAPIHelper alloc]
     								[self downloadThumbnailForPhotoModel:model];
 
     								return model;
-    							}] array];
+    							}] array]];
 
     							[subject sendCompleted];
     						}


### PR DESCRIPTION
chapter5/basic_of_functionalReactivePixels.md  the line 166 miss ']' after array]
